### PR TITLE
Build under mac OS & bit of refactoring

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -8,7 +8,7 @@
 		"include_dirs":["src", "<!(node -e \"require('nan')\")"],
 
 		"conditions": [
-			['OS=="win"', {
+			["OS=='win'", {
 				"defines": [
 					"UNICODE",
 					"_UNICODE "
@@ -17,22 +17,22 @@
 					"src/win/win_tasklist.cpp"
 				],
 				"configurations": {
-					'Release': {
-					  'msvs_settings': {
-							'VCCLCompilerTool': {
-								'WarningLevel': 4,
-								'ExceptionHandling': 1,
-								'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4800, 4005]
+					"Release": {
+					  "msvs_settings": {
+							"VCCLCompilerTool": {
+								"WarningLevel": 4,
+								"ExceptionHandling": 1,
+								"DisableSpecificWarnings": [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4800, 4005]
 							}
 					  }
 					},
 
-					'Debug': {
-					  'msvs_settings': {
-							'VCCLCompilerTool': {
-								'WarningLevel': 4,
-								'ExceptionHandling': 1,
-								'DisableSpecificWarnings': [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4800, 4005]
+					"Debug": {
+					  "msvs_settings": {
+							"VCCLCompilerTool": {
+								"WarningLevel": 4,
+								"ExceptionHandling": 1,
+								"DisableSpecificWarnings": [4100, 4127, 4201, 4244, 4267, 4506, 4611, 4714, 4800, 4005]
 							}
 					  }
 					}
@@ -41,15 +41,24 @@
 				"sources": [
 					"src/unix/tasklist.cpp"
 				],
-				'cflags_cc!': ['-fno-rtti', '-fno-exceptions'],
+				"cflags_cc!": ["-fno-rtti", "-fno-exceptions"],
 				"cflags_cc+": [
 					"-fexceptions",
 					"-std=c++0x",
-					'-frtti'
+					"-frtti"
 				]
 			}],
-			['OS=="mac"', {
-			    'xcode_settings': { 'GCC_ENABLE_CPP_RTTI': 'YES' }
+			["OS=='mac'", {
+				"xcode_settings": {
+					"GCC_ENABLE_CPP_RTTI": "YES",
+					"OTHER_CFLAGS": [
+						"-fexceptions",
+						"-std=c++11",
+						"-stdlib=libc++",
+						"-frtti",
+						"-mmacosx-version-min=10.7"
+			    	]
+				},
 			}]
 		]
 	},


### PR DESCRIPTION
I ran accros a problem when compiling process-list on Mac OS. Mainly, it was caused by clang not recognizing C++11 std::shared_ptr.

I propose this fix, which compiles successfully on Mac OS X 10.10, and also (but not tested) on Mac OS 10.7 or newer.

I also propose a little unification in the quoted string symbol : use of double quote everywhere.
